### PR TITLE
Support ignored routes in config file

### DIFF
--- a/tidyhtml.php
+++ b/tidyhtml.php
@@ -55,6 +55,8 @@ class TidyhtmlPlugin extends Plugin
      */
     public function onOutputGenerated()
     {
+            if(in_array($this->grav['uri']->path(), (array) $this->config->get('plugins.tidyhtml.ignores') )) return;
+            
             $originOutput = $this->grav->output;
 
             $config = array(


### PR DESCRIPTION
This would fix #2 by adding support for an ignore list in the configuration file.

It's an ugly one-liner, so you might want to split it into two or more lines.

tidyhtml.yaml example:

```
ignores:
  - /sitemap
  - /another-page-that-breaks-with-tidy-and-shouldnt-be-processed
```
